### PR TITLE
Cargo lints to cargo clippy

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,9 +6,9 @@
   types: [rust]
   args: ["--", "--check"]
 - id: clippy
-  name: cargo lints clippy
+  name: cargo clippy
   description: Lint rust sources
-  entry: cargo lints clippy
+  entry: cargo clippy
   language: system
   args: ["--workspace", "--all-targets", "--", "-D", "warnings"]
   types: [rust]


### PR DESCRIPTION
No need for `cargo-lints` now, plus it's unmaintained and buggy